### PR TITLE
feat: Tune for newly deployed functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ build:
 push:
 	docker push openfaas/faas-idler:${TAG}
 
+.PHONY: marvin-build
+marvin-build:
+	docker build -t cr-preview.pentium.network/faas-idler:${TAG} .
+
+.PHONY: marvin-push
+marvin-push:
+	docker push cr-preview.pentium.network/faas-idler:${TAG}
+
 .PHONY: ci-armhf-build
 ci-armhf-build:
 	docker build -t openfaas/faas-idler:${TAG}-armhf . -f Dockerfile.armhf

--- a/main.go
+++ b/main.go
@@ -304,7 +304,9 @@ func reconcile(client *http.Client, config types.Config, credentials *Credential
 
 		if firstCheck == float64(0) && secondCheck == float64(0) {
 			fmt.Printf("SCALE\t%s\tTO ZERO ...\n", function.Name)
-			sendScaleEvent(client, config.GatewayURL, function.Name, uint64(0), credentials)
+			if val, _ := getReplicas(client, config.GatewayURL, function.Name, credentials); val != nil && val.AvailableReplicas > 0 {
+				sendScaleEvent(client, config.GatewayURL, function.Name, uint64(0), credentials)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Implemented a new method scaleCriteria(), which is invoked in reconcile().
Instead of buildMetricMap() and then sendScaleEvent() after,  reconcile method now
checks scaling criteria first, and then send scale event() on the fly for every openfaas functions.

  * skip those functions w/o labels
  * check if the case is for a newly deployed functions
    a. if it is below inactivity_duration: keep it
    b. if it is over inactivity_duration: kill it
  * normal case stick with original openfaas implementation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

I have:

- [ ] updated the documentation if required
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

