### PR TITLE
Newly deployed functions go routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ build:
 push:
 	docker push openfaas/faas-idler:${TAG}
 
+.PHONY: marvin-build
+marvin-build:
+	docker build -t cr-preview.pentium.network/faas-idler:${TAG} .
+
+.PHONY: marvin-push
+marvin-push:
+	docker push cr-preview.pentium.network/faas-idler:${TAG}
+
 .PHONY: ci-armhf-build
 ci-armhf-build:
 	docker build -t openfaas/faas-idler:${TAG}-armhf . -f Dockerfile.armhf

--- a/main.go
+++ b/main.go
@@ -87,9 +87,10 @@ reconcile_interval: %s
 	}
 
 	for {
+		fmt.Println ("===== started =====")
 		reconcile(client, config, &credentials)
 		time.Sleep(config.ReconcileInterval)
-		fmt.Printf("\n")
+//		fmt.Printf("\n")
 	}
 }
 
@@ -358,9 +359,10 @@ func reconcile(client *http.Client, config types.Config, credentials *Credential
 	functions, err := queryFunctions(client, config.GatewayURL, credentials)
 
 	if err != nil {
-		log.Println(err)
+		log.Println("Warn)", err)
 		return
 	}
+	fmt.Println ("Debug)", "function list fetched")
 
 	// double confirm for the sake of 15 second scrape buffering
 	for _, function := range functions {
@@ -432,10 +434,10 @@ func reconcile(client *http.Client, config types.Config, credentials *Credential
 
 //					sendScaleEvent(client, config.GatewayURL, function.Name, uint64(0), credentials)
 				} else {
-//					fmt.Println("Info)", "IGNORE because replicas is 0 -------------------")
+					fmt.Println("Info)", "IGNORE because replicas is 0 -------------------")
 				}
 			} else {
-//				fmt.Println ("Info)", function.Name, "ignored due to ScaleConfirmCount:", ScaleConfirmCount)
+				fmt.Println ("Info)", function.Name, "ignored due to ScaleConfirmCount:", ScaleConfirmCount)
 			}
 
 		}(client, function, config, credentials)

--- a/main.go
+++ b/main.go
@@ -304,7 +304,9 @@ func reconcile(client *http.Client, config types.Config, credentials *Credential
 
 		if firstCheck == float64(0) && secondCheck == float64(0) {
 			fmt.Printf("SCALE\t%s\tTO ZERO ...\n", function.Name)
-			sendScaleEvent(client, config.GatewayURL, function.Name, uint64(0), credentials)
+			if val, _ := getReplicas(client, config.GatewayURL, function.Name, credentials); val != nil && val.AvailableReplicas > 0 {
+				sendScaleEvent(client, config.GatewayURL, function.Name, uint64(0), credentials)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -377,9 +377,9 @@ func reconcile(client *http.Client, config types.Config, credentials *Credential
 			retvalBefore := testGateway(function.Name)
 //			fmt.Println ("Debug)", function.Name, retvalBefore )
 
-			var _output string = ""
+//			var _output string = ""
 
-			realScale := 0
+			ScaleConfirmCount := 0
 			for i := 0; i < 2; i++ {
 				// fmt.Println("------------------------------------------------------------------------------------------")
 				// fmt.Println("")
@@ -402,22 +402,23 @@ func reconcile(client *http.Client, config types.Config, credentials *Credential
 				replicaSize, _ := getReplicas(client, config.GatewayURL, function.Name, credentials)
 				if firstCheck == float64(0) && secondCheck == float64(0) && replicaSize.AvailableReplicas > 0 {
 
-					realScale++
+					ScaleConfirmCount++
 					// time.Sleep(time.Second * 2)
-					fmt.Printf("realScale++: %v\t%v\n", realScale, function.Name)
+					fmt.Printf("ScaleConfirmCount++: %v\t%v\n", ScaleConfirmCount, function.Name)
 
 				}
 
-				// fmt.Printf("realScale: %v\n", realScale)
+				// fmt.Printf("ScaleConfirmCount: %v\n", ScaleConfirmCount)
 				// fmt.Println("**************** end point ", i)
 				time.Sleep(time.Second * prometheusScrapeInterval)
 
 			}
 
-			if realScale == 2 {
+			if ScaleConfirmCount == 2 {
 				if val, _ := getReplicas(client, config.GatewayURL, function.Name, credentials); val != nil && val.AvailableReplicas > 0 {
-					fmt.Printf("realScale: %v\n", realScale)
-					fmt.Printf("SCALE\t%s\tTO ZERO ...\n", function.Name)
+//					fmt.Printf("ScaleConfirmCount: %v\n", ScaleConfirmCount)
+//					fmt.Printf("SCALE\t%s\tTO ZERO ...\n", function.Name)
+					fmt.Printf("Debug) scale %s to 0 due to ScaleConfirmCount: %v\n", function.Name, ScaleConfirmCount)
 
 					// TODO:
 					retval := testGateway(function.Name)


### PR DESCRIPTION
## Description
Implemented a new method scaleCriteria(), which is invoked in reconcile().
Instead of buildMetricMap() and then sendScaleEvent() after, reconcile method now
checks scaling criteria first, and then send scale event() on the fly for every openfaas functions.

1 .skip those functions w/o labels
2. check if the case is for a newly deployed functions
    a. if it is below inactivity_duration: keep it
    b. if it is over inactivity_duration: kill it
3. normal case stick with original openfaas implementation
4. go routine is implemented
5. double confirm: with sleep interval in between two confirmation checks


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

I have:

- [ ] updated the documentation if required
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

